### PR TITLE
Added option to tickNextTickListCap to always process redstone

### DIFF
--- a/Spigot-Server-Patches/0047-Added-option-to-tickNextTickListCap-to-always-proces.patch
+++ b/Spigot-Server-Patches/0047-Added-option-to-tickNextTickListCap-to-always-proces.patch
@@ -1,0 +1,73 @@
+From 3d86468c03997295b780e4b13b15ddfc7ab7d2c7 Mon Sep 17 00:00:00 2001
+From: Roman Alexander <romanalexander@users.noreply.github.com>
+Date: Thu, 26 Mar 2015 01:05:30 -0400
+Subject: [PATCH] Added option to tickNextTickListCap to always process
+ redstone on that iteration.
+
+
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index a7da9c2..99ab2d7 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -538,6 +538,7 @@ public class WorldServer extends World {
+                 // CraftBukkit end
+             } */
+ 
++            int initial_i = i;
+             if (i > paperSpigotConfig.tickNextTickListCap) {
+                 i = paperSpigotConfig.tickNextTickListCap;
+             }
+@@ -547,7 +548,8 @@ public class WorldServer extends World {
+ 
+             NextTickListEntry nextticklistentry;
+ 
+-            for (int j = 0; j < i; ++j) {
++            int j;
++            for (j = 0; j < i; ++j) {
+                 nextticklistentry = (NextTickListEntry) this.N.first();
+                 if (!flag && nextticklistentry.d > this.worldData.getTime()) {
+                     break;
+@@ -558,6 +560,22 @@ public class WorldServer extends World {
+                 this.V.add(nextticklistentry);
+             }
+ 
++            if (paperSpigotConfig.tickNextTickListCapIgnoresRedstone) {
++                Iterator<NextTickListEntry> iterator = this.N.iterator();
++                while (iterator.hasNext()) {
++                    NextTickListEntry next = iterator.next();
++                    if (!flag && next.d > this.worldData.getTime()) {
++                        break;
++                    }
++
++                    if (next.a().isPowerSource() || next.a() instanceof IContainer) {
++                        iterator.remove();
++                        this.M.remove(next);
++                        this.V.add(next);
++                    }
++                }
++            }
++
+             this.methodProfiler.b();
+             this.methodProfiler.a("ticking");
+             Iterator iterator = this.V.iterator();
+diff --git a/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java b/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java
+index 4b719ec..4e306bc 100644
+--- a/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java
++++ b/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java
+@@ -198,10 +198,13 @@ public class PaperSpigotWorldConfig
+     }
+ 
+     public int tickNextTickListCap;
++    public boolean tickNextTickListCapIgnoresRedstone;
+     private void tickNextTickListCap()
+     {
+         tickNextTickListCap = getInt( "tick-next-tick-list-cap", 10000 ); // Higher values will be friendlier to vanilla style mechanics (to a point) but may hurt performance
++        tickNextTickListCapIgnoresRedstone = getBoolean("tick-next-tick-list-cap-ignores-redstone", false); // Redstone TickNextTicks will always bypass the preceding cap.
+         log( "WorldServer TickNextTickList cap set at " + tickNextTickListCap );
++        log( "WorldServer TickNextTickList cap always processes redstone: " + tickNextTickListCapIgnoresRedstone );
+     }
+ 
+     public boolean useAsyncLighting;
+-- 
+1.9.5.msysgit.0
+


### PR DESCRIPTION
Tested with placing all redstone physics blocks on a redstone clock.
- Piston
- Sticky Piston
- Doors
- Minecart activators
- Repeaters
- Fence Gates
- Daylight sensors
- Comparators
- Dispensers
