### PR TITLE
Optimize draining

### DIFF
--- a/Spigot-Server-Patches/0053-Optimize-draining.patch
+++ b/Spigot-Server-Patches/0053-Optimize-draining.patch
@@ -1,0 +1,48 @@
+From 026bf00dfddcd3e82aa47deaa666f31b0776fff4 Mon Sep 17 00:00:00 2001
+From: Byteflux <byte@byteflux.net>
+Date: Fri, 10 Apr 2015 02:24:20 -0700
+Subject: [PATCH] Optimize draining
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockFlowing.java b/src/main/java/net/minecraft/server/BlockFlowing.java
+index 6409391..fd33a1e 100644
+--- a/src/main/java/net/minecraft/server/BlockFlowing.java
++++ b/src/main/java/net/minecraft/server/BlockFlowing.java
+@@ -88,7 +88,18 @@ public class BlockFlowing extends BlockFluids {
+                 } else {
+                     world.setData(i, j, k, j1, 2);
+                     world.a(i, j, k, this, i1);
+-                    world.applyPhysics(i, j, k, this);
++                    // PaperSpigot start - Optimize draining
++                    if (world.paperSpigotConfig.optimizeDraining) {
++                        world.e(i - 1, j, k, this);
++                        world.e(i + 1, j, k, this);
++                        world.e(i, j + 1, k, this);
++                        world.e(i, j, k - 1, this);
++                        world.e(i, j, k + 1, this);
++                        world.spigotConfig.antiXrayInstance.updateNearbyBlocks(world, i, j, k); // Spigot
++                    } else {
++                        world.applyPhysics(i, j, k, this);
++                    }
++                    // PaperSpigot end
+                 }
+             }
+         } else {
+diff --git a/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java b/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java
+index 037fbc0..745f4a7 100644
+--- a/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java
++++ b/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java
+@@ -242,4 +242,10 @@ public class PaperSpigotWorldConfig
+         entityMaxTickTime = getInt( "max-tick-time-entity", 50 );
+         log( "Entity max Tick Time: " + entityMaxTickTime + "ms" );
+     }
++
++    public boolean optimizeDraining;
++    private void optimizeDraining()
++    {
++        optimizeDraining = getBoolean( "optimize-draining", false );
++    }
+ }
+-- 
+1.9.4.msysgit.2
+


### PR DESCRIPTION
Removes a (mostly?) unnecessary physics update while draining water and lava that causes a bunch of extraneous next tick list entries to be scheduled.

This optimization is off by default and can be enabled through the configuration. There may be side effects or minor trade offs so it's probably best to keep it configurable.
