### PR TITLE
Fix chunks not force loading if entity moves >16m/tick

### DIFF
--- a/Spigot-Server-Patches/0054-Force-load-chunks-for-specific-entities-that-fly-thr.patch
+++ b/Spigot-Server-Patches/0054-Force-load-chunks-for-specific-entities-that-fly-thr.patch
@@ -1,9 +1,114 @@
-From 4ab434e1b139e8f55e69e54896513c608a06502d Mon Sep 17 00:00:00 2001
+From ff6332741bc4c1c85edf62a91976173101da61d9 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Mon, 13 Apr 2015 15:58:18 -0500
 Subject: [PATCH] Force load chunks for specific entities that fly through
 
 
+diff --git a/src/main/java/net/minecraft/server/EntityEnderPearl.java b/src/main/java/net/minecraft/server/EntityEnderPearl.java
+index 9376a1d..a29f65f 100644
+--- a/src/main/java/net/minecraft/server/EntityEnderPearl.java
++++ b/src/main/java/net/minecraft/server/EntityEnderPearl.java
+@@ -63,4 +63,24 @@ public class EntityEnderPearl extends EntityProjectile {
+             this.die();
+         }
+     }
++
++    // PaperSpigot start - Force load chunks for specific entities that fly through
++    public void h() {
++        if (world.paperSpigotConfig.loadUnloadedEnderPearls) {
++            ChunkProviderServer chunkProvider = (ChunkProviderServer) world.chunkProvider;
++            boolean before = chunkProvider.forceChunkLoad;
++            chunkProvider.forceChunkLoad = true;
++
++            for (int cx = (int) locX >> 4; cx <= (int) (locX + motX) >> 4; ++cx) {
++                for (int cz = (int) locZ >> 4; cz <= (int) (locZ + motZ) >> 4; ++cz) {
++                    world.getChunkAt(cx, cz);
++                }
++            }
++
++            chunkProvider.forceChunkLoad = before;
++        }
++
++        super.h();
++    }
++    // PaperSpigot end
+ }
+diff --git a/src/main/java/net/minecraft/server/EntityFallingBlock.java b/src/main/java/net/minecraft/server/EntityFallingBlock.java
+index 51d2505..ce89938 100644
+--- a/src/main/java/net/minecraft/server/EntityFallingBlock.java
++++ b/src/main/java/net/minecraft/server/EntityFallingBlock.java
+@@ -72,6 +72,21 @@ public class EntityFallingBlock extends Entity {
+         if (this.id.getMaterial() == Material.AIR) {
+             this.die();
+         } else {
++            // PaperSpigot start - Force load chunks for specific entities that fly through
++            if (world.paperSpigotConfig.loadUnloadedFallingBlocks) {
++                ChunkProviderServer chunkProvider = (ChunkProviderServer) world.chunkProvider;
++                boolean before = chunkProvider.forceChunkLoad;
++                chunkProvider.forceChunkLoad = true;
++
++                for (int cx = (int) locX >> 4; cx <= (int) (locX + motX) >> 4; ++cx) {
++                    for (int cz = (int) locZ >> 4; cz <= (int) (locZ + motZ) >> 4; ++cz) {
++                        world.getChunkAt(cx, cz);
++                    }
++                }
++
++                chunkProvider.forceChunkLoad = before;
++            }
++            // PaperSpigot end
+             this.lastX = this.locX;
+             this.lastY = this.locY;
+             this.lastZ = this.locZ;
+diff --git a/src/main/java/net/minecraft/server/EntityTNTPrimed.java b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
+index 8aa1663..380fcca 100644
+--- a/src/main/java/net/minecraft/server/EntityTNTPrimed.java
++++ b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
+@@ -53,6 +53,21 @@ public class EntityTNTPrimed extends Entity {
+ 
+     public void h() {
+         if (world.spigotConfig.currentPrimedTnt++ > world.spigotConfig.maxTntTicksPerTick) { return; } // Spigot
++        // PaperSpigot start - Force load chunks for specific entities that fly through
++        if (world.paperSpigotConfig.loadUnloadedTNTEntities) {
++            ChunkProviderServer chunkProvider = (ChunkProviderServer) world.chunkProvider;
++            boolean before = chunkProvider.forceChunkLoad;
++            chunkProvider.forceChunkLoad = true;
++
++            for (int cx = (int) locX >> 4; cx <= (int) (locX + motX) >> 4; ++cx) {
++                for (int cz = (int) locZ >> 4; cz <= (int) (locZ + motZ) >> 4; ++cz) {
++                    world.getChunkAt(cx, cz);
++                }
++            }
++
++            chunkProvider.forceChunkLoad = before;
++        }
++        // PaperSpigot end
+         this.lastX = this.locX;
+         this.lastY = this.locY;
+         this.lastZ = this.locZ;
+@@ -95,8 +110,21 @@ public class EntityTNTPrimed extends Entity {
+         server.getPluginManager().callEvent(event);
+ 
+         if (!event.isCancelled()) {
+-            // give 'this' instead of (Entity) null so we know what causes the damage
+-            this.world.createExplosion(this, this.locX, this.locY, this.locZ, event.getRadius(), event.getFire(), true);
++            // PaperSpigot start - Force load chunks for specific entities that fly through
++            if (world.paperSpigotConfig.loadUnloadedTNTEntities) {
++                ChunkProviderServer chunkProvider = (ChunkProviderServer) world.chunkProvider;
++                boolean before = chunkProvider.forceChunkLoad;
++                chunkProvider.forceChunkLoad = true;
++
++                // give 'this' instead of (Entity) null so we know what causes the damage
++                this.world.createExplosion(this, this.locX, this.locY, this.locZ, event.getRadius(), event.getFire(), true);
++
++                chunkProvider.forceChunkLoad = before;
++            } else {
++                // give 'this' instead of (Entity) null so we know what causes the damage
++                this.world.createExplosion(this, this.locX, this.locY, this.locZ, event.getRadius(), event.getFire(), true);
++            }
++            // PaperSpigot end
+         }
+         // CraftBukkit end
+     }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
 index 7cbb33b..5fb1509 100644
 --- a/src/main/java/net/minecraft/server/World.java
@@ -27,7 +132,7 @@ index 7cbb33b..5fb1509 100644
                      entity.ag = false;
                  }
 diff --git a/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java b/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java
-index 745f4a7..171d94c 100644
+index 745f4a7..2d55742 100644
 --- a/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java
 +++ b/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java
 @@ -243,9 +243,20 @@ public class PaperSpigotWorldConfig
@@ -38,9 +143,8 @@ index 745f4a7..171d94c 100644
      public boolean optimizeDraining;
      private void optimizeDraining()
      {
--        optimizeDraining = getBoolean( "optimize-draining", false );
-+        optimizeDraining = getBoolean("optimize-draining", false);
-+    }
+         optimizeDraining = getBoolean( "optimize-draining", false );
+     }
 +
 +    public boolean loadUnloadedEnderPearls;
 +    public boolean loadUnloadedTNTEntities;
@@ -50,7 +154,7 @@ index 745f4a7..171d94c 100644
 +        loadUnloadedEnderPearls = getBoolean( "load-chunks.enderpearls", false );
 +        loadUnloadedTNTEntities = getBoolean( "load-chunks.tnt-entities", false );
 +        loadUnloadedFallingBlocks = getBoolean( "load-chunks.falling-blocks", false );
-     }
++    }
  }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
 index 6fea403..06145fc 100644


### PR DESCRIPTION
It's possible for entities to move so quickly that their velocity permits them to skip chunks. In these cases it's important to load the chunks in the direction the entity is moving ahead of time so that entity<->block collisions can be properly determined by the movement code.
