### PR TITLE
Configurable full size blocks

### DIFF
--- a/Spigot-Server-Patches/0056-Configurable-full-size-blocks.patch
+++ b/Spigot-Server-Patches/0056-Configurable-full-size-blocks.patch
@@ -1,0 +1,62 @@
+From 458da9163aaf5a855990fdcc1d2d3656950b7a25 Mon Sep 17 00:00:00 2001
+From: Byteflux <byte@byteflux.net>
+Date: Mon, 20 Apr 2015 11:37:08 -0700
+Subject: [PATCH] Configurable full size blocks
+
+
+diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
+index 24e84d6..778cdb8 100644
+--- a/src/main/java/net/minecraft/server/Block.java
++++ b/src/main/java/net/minecraft/server/Block.java
+@@ -1,5 +1,7 @@
+ package net.minecraft.server;
+ 
++import org.github.paperspigot.PaperSpigotConfig; // PaperSpigot
++
+ import java.util.Iterator;
+ import java.util.List;
+ import java.util.Random;
+@@ -387,6 +389,12 @@ public class Block {
+     }
+ 
+     protected final void a(float f, float f1, float f2, float f3, float f4, float f5) {
++        // PaperSpigot start - Configurable full size blocks
++        if (PaperSpigotConfig.fullSizeBlocks.contains(getId(this))) {
++            f = f1 = f2 = 0.0F;
++            f3 = f4 = f5 = 1.0F;
++        }
++        // PaperSpigot end
+         this.minX = (double) f;
+         this.minY = (double) f1;
+         this.minZ = (double) f2;
+diff --git a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+index df42019..38f817b 100644
+--- a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
++++ b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+@@ -6,9 +6,12 @@ import java.io.IOException;
+ import java.lang.reflect.InvocationTargetException;
+ import java.lang.reflect.Method;
+ import java.lang.reflect.Modifier;
++import java.util.Collections;
+ import java.util.HashMap;
++import java.util.HashSet;
+ import java.util.List;
+ import java.util.Map;
++import java.util.Set;
+ import java.util.logging.Level;
+ import net.minecraft.server.MinecraftServer;
+ import org.bukkit.Bukkit;
+@@ -175,4 +178,10 @@ public class PaperSpigotConfig
+     {
+         maxPacketsPerPlayer = getInt( "max-packets-per-player", 1000 );
+     }
++
++    public static Set<Integer> fullSizeBlocks;
++    private static void fullSizeBlocks()
++    {
++        fullSizeBlocks = new HashSet<Integer>( getList( "full-size-blocks", Collections.emptyList() ) );
++    }
+ }
+-- 
+1.9.4.msysgit.2
+


### PR DESCRIPTION
Allows you to configure which blocks will be treated as full size blocks. This is handy for Factions servers with cannoning since you can't stack sand against certain blocks which makes for overpowered defenses.
