### PR TITLE
FallingBlock and TNT entities collide with specific blocks

### DIFF
--- a/Spigot-Server-Patches/0056-FallingBlock-and-TNT-entities-collide-with-specific-.patch
+++ b/Spigot-Server-Patches/0056-FallingBlock-and-TNT-entities-collide-with-specific-.patch
@@ -1,0 +1,45 @@
+From 89b1e505c2421758a2b774b4e49b2303b3c1f4e0 Mon Sep 17 00:00:00 2001
+From: Byteflux <byte@byteflux.net>
+Date: Tue, 21 Apr 2015 01:36:02 -0700
+Subject: [PATCH] FallingBlock and TNT entities collide with specific blocks
+
+
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index 5fb1509..34c91d7 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -1275,7 +1273,15 @@ public abstract class World implements IBlockAccess {
+                             Block block = chunk.getType(x - cx, y, z - cz );
+                             if ( block != null )
+                             {
+-                                block.a( this, x, y, z, axisalignedbb, this.L, entity );
++                                // PaperSpigot start - FallingBlocks and TNT collide with specific non-collidable blocks
++                                if (entity.world.paperSpigotConfig.fallingBlocksCollideWithSigns && (entity instanceof EntityTNTPrimed || entity instanceof EntityFallingBlock) &&
++                                        (block instanceof BlockSign || block instanceof BlockFenceGate || block instanceof BlockTorch || block instanceof BlockButtonAbstract || block instanceof BlockLever || block instanceof BlockTripwireHook)) {
++                                    AxisAlignedBB aabb = AxisAlignedBB.a(x, y, z, x + 1.0, y + 1.0, z + 1.0);
++                                    if (axisalignedbb.b(aabb)) this.L.add(aabb);
++                                } else {
++                                    block.a( this, x, y, z, axisalignedbb, this.L, entity );
++                                }
++                                // PaperSpigot end
+                             }
+                         }
+                     }
+diff --git a/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java b/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java
+index 2d55742..6961328 100644
+--- a/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java
++++ b/src/main/java/org/github/paperspigot/PaperSpigotWorldConfig.java
+@@ -259,4 +259,10 @@ public class PaperSpigotWorldConfig
+         loadUnloadedTNTEntities = getBoolean( "load-chunks.tnt-entities", false );
+         loadUnloadedFallingBlocks = getBoolean( "load-chunks.falling-blocks", false );
+     }
++
++    public boolean fallingBlocksCollideWithSigns;
++    private void fallingBlocksCollideWithSigns()
++    {
++        fallingBlocksCollideWithSigns = getBoolean( "falling-blocks-collide-with-signs", false );
++    }
+ }
+-- 
+1.9.4.msysgit.2
+


### PR DESCRIPTION
When enabled, falling block and TNT entities will collide with specific blocks such as signs, fence gates etc. This allows sand to stack on these blocks and also allows cannons to slabbust these blocks if they're not water protected.

There is a good reason for cannoning-based Factions servers to enable this setting because when these simple blocks are used as a base defense, cannoning becomes much more difficult than it should be.
