### PR TITLE
Handle player login thread in a pool

### DIFF
--- a/Spigot-Server-Patches/0084-Handle-player-login-thread-in-a-poll.patch
+++ b/Spigot-Server-Patches/0084-Handle-player-login-thread-in-a-poll.patch
@@ -1,0 +1,91 @@
+From 4b888268ce4f514db54b2f3cbf5e575b550a8138 Mon Sep 17 00:00:00 2001
+From: caoli5288 <caoli5288@gmail.com>
+Date: Thu, 6 Aug 2015 21:00:09 +0800
+Subject: [PATCH] Handle player login thread in a poll
+
+
+diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
+index bd254de..f4807de 100644
+--- a/src/main/java/net/minecraft/server/LoginListener.java
++++ b/src/main/java/net/minecraft/server/LoginListener.java
+@@ -4,7 +4,14 @@ import java.security.PrivateKey;
+ import java.util.Arrays;
+ import java.util.Random;
+ import java.util.UUID;
++import java.util.concurrent.Executor;
++import java.util.concurrent.ExecutorService;
++import java.util.concurrent.Executors;
++import java.util.concurrent.LinkedBlockingQueue;
++import java.util.concurrent.ThreadPoolExecutor;
++import java.util.concurrent.TimeUnit;
+ import java.util.concurrent.atomic.AtomicInteger;
++
+ import javax.crypto.SecretKey;
+ 
+ import net.minecraft.util.com.google.common.base.Charsets;
+@@ -13,12 +20,12 @@ import net.minecraft.util.com.mojang.authlib.properties.Property;
+ import net.minecraft.util.io.netty.util.concurrent.Future;
+ import net.minecraft.util.io.netty.util.concurrent.GenericFutureListener;
+ import net.minecraft.util.org.apache.commons.lang3.Validate;
++
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
+ public class LoginListener implements PacketLoginInListener {
+ 
+-    private static final AtomicInteger b = new AtomicInteger(0);
+     private static final Logger c = LogManager.getLogger();
+     private static final Random random = new Random();
+     private final byte[] e = new byte[4];
+@@ -30,6 +37,11 @@ public class LoginListener implements PacketLoginInListener {
+     private String j;
+     private SecretKey loginKey;
+     public String hostname = ""; // CraftBukkit - add field
++    
++    private static final ExecutorService POOL = new ThreadPoolExecutor(2, 
++    		Runtime.getRuntime().availableProcessors() * 2, 
++    		60, TimeUnit.SECONDS, 
++    		new LinkedBlockingQueue()); // PaperSpigot
+ 
+     public LoginListener(MinecraftServer minecraftserver, NetworkManager networkmanager) {
+         this.g = EnumProtocolState.HELLO;
+@@ -140,7 +152,7 @@ public class LoginListener implements PacketLoginInListener {
+             this.g = EnumProtocolState.KEY;
+             this.networkManager.handle(new PacketLoginOutEncryptionBegin(this.j, this.server.K().getPublic(), this.e), new GenericFutureListener[0]);
+         } else {
+-            (new ThreadPlayerLookupUUID(this, "User Authenticator #" + b.incrementAndGet())).start(); // Spigot
++            POOL.execute(new ThreadPlayerLookupUUID(this)); // PaperSpigot
+         }
+     }
+ 
+@@ -154,7 +166,7 @@ public class LoginListener implements PacketLoginInListener {
+             this.loginKey = packetlogininencryptionbegin.a(privatekey);
+             this.g = EnumProtocolState.AUTHENTICATING;
+             this.networkManager.a(this.loginKey);
+-            (new ThreadPlayerLookupUUID(this, "User Authenticator #" + b.incrementAndGet())).start();
++            POOL.execute(new ThreadPlayerLookupUUID(this));
+         }
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/ThreadPlayerLookupUUID.java b/src/main/java/net/minecraft/server/ThreadPlayerLookupUUID.java
+index 1b2620c..ae074c8 100644
+--- a/src/main/java/net/minecraft/server/ThreadPlayerLookupUUID.java
++++ b/src/main/java/net/minecraft/server/ThreadPlayerLookupUUID.java
+@@ -12,12 +12,11 @@ import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+ import org.bukkit.event.player.PlayerPreLoginEvent;
+ // CraftBukkit end
+ 
+-class ThreadPlayerLookupUUID extends Thread {
++class ThreadPlayerLookupUUID implements Runnable {
+ 
+     final LoginListener a;
+ 
+-    ThreadPlayerLookupUUID(LoginListener loginlistener, String s) {
+-        super(s);
++    ThreadPlayerLookupUUID(LoginListener loginlistener) {
+         this.a = loginlistener;
+     }
+ 
+-- 
+2.4.3
+


### PR DESCRIPTION
I have submitted this patch to the spigot community to stop hackers attacking offline server but be rejected.
Some people can easily code a tool to send packet to produce a large number of threads server to cause server lag (or crash).See #46 .
This patch can be simple to prevent this situation, although not perfect.(Will cause normal players to be hard to join when the server is under attack. Better than server crash.)
